### PR TITLE
fix: use slot specific runeword when loading from url params

### DIFF
--- a/data/functions.js
+++ b/data/functions.js
@@ -546,12 +546,14 @@ function loadParams() {
     const params = new URLSearchParams(window.location.search);
 
     // --- Helpers ---
-    function findRunewordByName(name) {
+    function findRunewordByName(name, slot) {
         if (!name) return null;
         const n = String(name).trim().toLowerCase();
         for (let k in runewordProperties) {
             const rp = runewordProperties[k];
             if (!rp) continue;
+			const isSlotMatch = rp.allowedCategories.includes(slot);
+			if (!isSlotMatch) continue; // skip runeword variations that aren't valid for the current slot, eg. phoenix in the offhand slot should skip the first weapon variant
             if ((rp.name && rp.name.toLowerCase() === n) || k.toLowerCase() === n) return rp;
         }
         return null;
@@ -795,7 +797,7 @@ if (rarity === "rw" || name.includes(" - ")) {
 
             // Robustly find the runeword object (works if keys or display name are used)
             const runewordObj =
-                (typeof findRunewordByName === "function" && findRunewordByName(rwName))
+                (typeof findRunewordByName === "function" && findRunewordByName(rwName, slot))
                 || runewordProperties[rwName]
                 || runewordProperties[rwName.toLowerCase()];
 


### PR DESCRIPTION
Runewords that have variants for different slots such as Phoenix can populate using the wrong stats for the slot when using the shareable url. This PR adds a slot check so that runewords with the matching name but the wrong slot are skipped during initial selection. You can see this in effect when Phoenix shield is equipped as it will reload with the stats for the weapon variant. [Example link](https://build.pathofdiablo.com/?v=2&url=1&class=amazon&level=1&difficulty=3&quests=1&running=0&strength=0&dexterity=0&vitality=0&energy=0&coupling=1&synthwep=0&autocast=1&skills=000000000000000000000000000000000000000000000000000000000000&selected=+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+1%2C+%C2%AD+%C2%AD+%C2%AD+%C2%AD+Skill+2&offhand=Phoenix+%C2%AD+%C2%AD+-+%C2%AD+%C2%AD+Monarch+-+Monarch&effect=Redemption-offhand%2C1%2C0&effect=Blaze-offhand%2C1%2C0&mercenary=none%2Cnone%2Cnone%2Cnone%2Cnone).